### PR TITLE
Fixed Quaternion `IsNearly`

### DIFF
--- a/WasaBii-unity-project/Packages/WasaBii/WasaBii-Geometry/SystemQuaternionExtensions.cs
+++ b/WasaBii-unity-project/Packages/WasaBii/WasaBii-Geometry/SystemQuaternionExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using BII.WasaBii.Core;
 using BII.WasaBii.UnitSystem;
 using JetBrains.Annotations;
 
@@ -13,11 +12,13 @@ namespace BII.WasaBii.Geometry
         
         [Pure] public static Quaternion Inverse(this Quaternion q) => Quaternion.Inverse(q);
         
-        [Pure] public static bool IsNearly(this Quaternion self, Quaternion other, double threshold = 1E-06) =>
-            self.X.IsNearly(other.X, (float)threshold)
-            && self.Y.IsNearly(other.Y, (float)threshold)
-            && self.Z.IsNearly(other.Z, (float)threshold)
-            && self.W.IsNearly(other.W, (float)threshold);
+        // Note DS: We cannot simply compare two quaternions component-wise because a quaternion and its negation
+        // represent the same orientation. So we could do the component-wise comparison twice with a negated and a
+        // non-negated rhs and return true if either comparison is true. However, this would be too much work,
+        // so we do this neat dot-product thing instead. https://gamedev.stackexchange.com/a/75108
+        // Note that this will only work for valid (unit-length) quaternions.
+        [Pure] public static bool IsNearly(this Quaternion lhs, Quaternion rhs, double equalityThreshold = 1E-06) => 
+            MathF.Abs(Quaternion.Dot(lhs, rhs)) >= 1 - equalityThreshold;
 
         [Pure]
         public static Quaternion SlerpTo(this Quaternion self, Quaternion other, double progress, bool shouldClamp = true) =>

--- a/WasaBii-unity-project/Packages/WasaBii/WasaBii-Geometry/UnityNumericsExtensions.cs
+++ b/WasaBii-unity-project/Packages/WasaBii/WasaBii-Geometry/UnityNumericsExtensions.cs
@@ -1,35 +1,39 @@
 ﻿#if UNITY_2022_1_OR_NEWER
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BII.WasaBii.Core;
 using BII.WasaBii.UnitSystem;
+using JetBrains.Annotations;
 using UnityEngine;
 
 namespace BII.WasaBii.Geometry
 {
     public static class UnityNumericsExtensions
     {
-        public static bool IsNearly(this Vector3 self, Vector3 other, double threshold = 1E-06) =>
+        [Pure] public static bool IsNearly(this Vector3 self, Vector3 other, double threshold = 1E-06) =>
             self.x.IsNearly(other.x, (float)threshold)
             && self.y.IsNearly(other.y, (float)threshold)
             && self.z.IsNearly(other.z, (float)threshold);
 
-        public static Vector3 LerpTo(this Vector3 from, Vector3 to, double progress, bool shouldClamp = true) =>
+        [Pure] public static Vector3 LerpTo(this Vector3 from, Vector3 to, double progress, bool shouldClamp = true) =>
             shouldClamp 
                 ? Vector3.Lerp(from, to, (float)progress)
                 : Vector3.LerpUnclamped(from, to, (float)progress);
 
-        public static Vector3 SlerpTo(this Vector3 from, Vector3 to, double progress, bool shouldClamp = true) =>
+        [Pure] public static Vector3 SlerpTo(this Vector3 from, Vector3 to, double progress, bool shouldClamp = true) =>
             shouldClamp 
                 ? Vector3.Slerp(from, to, (float)progress)
                 : Vector3.SlerpUnclamped(from, to, (float)progress);
 
-        public static bool IsNearly(this Quaternion lhs, Quaternion rhs, double equalityThreshold = 1E-06) => 
-            lhs.x.IsNearly(rhs.x, (float)equalityThreshold) 
-            && lhs.y.IsNearly(rhs.y, (float)equalityThreshold) 
-            && lhs.z.IsNearly(rhs.z, (float)equalityThreshold)
-            && lhs.w.IsNearly(rhs.w, (float)equalityThreshold);
+        // Note DS: We cannot simply compare two quaternions component-wise because a quaternion and its negation
+        // represent the same orientation. So we could do the component-wise comparison twice with a negated and a
+        // non-negated rhs and return true if either comparison is true. However, this would be too much work,
+        // so we do this neat dot-product thing instead. https://gamedev.stackexchange.com/a/75108
+        // Note that this will only work for valid (unit-length) quaternions.
+        [Pure] public static bool IsNearly(this Quaternion lhs, Quaternion rhs, double equalityThreshold = 1E-06) => 
+            MathF.Abs(Quaternion.Dot(lhs, rhs)) >= 1 - equalityThreshold;
 
         public static Vector3 Average(this IEnumerable<Vector3> vectors) =>
             vectors.Average((l, r) => l + r, (accum, count) => accum / count);
@@ -44,20 +48,20 @@ namespace BII.WasaBii.Geometry
             ).normalized;
         }
 
-        public static Quaternion SlerpTo(
+        [Pure] public static Quaternion SlerpTo(
             this Quaternion from, Quaternion to, double progress, bool shouldClamp = true
         ) => shouldClamp 
             ? Quaternion.Slerp(from, to, (float)progress) 
             : Quaternion.SlerpUnclamped(from, to, (float)progress);
 
-        public static Vector3 Min(this Vector3 a, Vector3 b) => Vector3.Min(a, b);
-        public static Vector3 Max(this Vector3 a, Vector3 b) => Vector3.Max(a, b);
+        [Pure] public static Vector3 Min(this Vector3 a, Vector3 b) => Vector3.Min(a, b);
+        [Pure] public static Vector3 Max(this Vector3 a, Vector3 b) => Vector3.Max(a, b);
 
         /// <inheritdoc cref="Vector3.Angle"/>
-        public static Angle AngleTo(this Vector3 from, Vector3 to) => Vector3.Angle(from, to).Degrees();
+        [Pure] public static Angle AngleTo(this Vector3 from, Vector3 to) => Vector3.Angle(from, to).Degrees();
         
         /// <inheritdoc cref="SystemVectorExtensions.SignedAngleTo"/>
-        public static Angle SignedAngleTo(this Vector3 from, Vector3 to, Vector3 axis, Handedness handedness) {
+        [Pure] public static Angle SignedAngleTo(this Vector3 from, Vector3 to, Vector3 axis, Handedness handedness) {
             var ret = Vector3.SignedAngle(from, to, axis).Degrees();
             return handedness switch {
                 Handedness.Left => ret,
@@ -67,7 +71,7 @@ namespace BII.WasaBii.Geometry
         }
 
         /// <inheritdoc cref="SystemVectorExtensions.SignedAngleOnPlaneTo"/>
-        public static Angle SignedAngleOnPlaneTo(this Vector3 from, Vector3 to, Vector3 axis, Handedness handedness) =>
+        [Pure] public static Angle SignedAngleOnPlaneTo(this Vector3 from, Vector3 to, Vector3 axis, Handedness handedness) =>
             from.ToSystemVector().SignedAngleOnPlaneTo(to.ToSystemVector(), axis.ToSystemVector(), handedness);
 
     }


### PR DESCRIPTION
Found a bug in the quaternion `IsNearly` comparison: A quaternion `q` and its negative `-q` represent the same orientation and should thus be considered "nearly the same". Therefore, the simple component-wise comparison does not work. I asked [the internet](https://gamedev.stackexchange.com/a/75108) and it said you can either do the component-wise comparison twice (once with the negated quaternion), or you can take the absolute of the dot product:
The dot product of two equal quaternions should be 1. If one is negated, it should be -1. The more the quaternions deviate, the more it tends toward 0. So we take the absolute of the dot product and compare that to 1 with the given threshold